### PR TITLE
Jest tests & plugin use same `removeHyperlinks()`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	preset: 'ts-jest'
+};

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { Editor, MarkdownView, Notice, Plugin } from 'obsidian';
+import { removeHyperlinks } from './removeHyperlinks';
 
 export default class HyperlinkRemover extends Plugin {
 	async onload() {
@@ -79,36 +80,3 @@ export default class HyperlinkRemover extends Plugin {
 	}
 }
 
-function removeHyperlinks(text:string): string {
-	let result = text;
-	let match;
-	const regex = /\[((?:[^\]\\]|\\.|\](?!\())*?)\]\(/g;
-
-	while ((match = regex.exec(text)) !== null) {
-		const linkText = match[1];
-		const startPos = match.index;
-		const urlStartPos = match.index + match[0].length;
-
-		// Find the matching closing parenthesis
-		let parenCount = 1;
-		let urlEndPos = urlStartPos;
-
-		while (urlEndPos < text.length && parenCount > 0) {
-			if (text[urlEndPos] === '(') {
-				parenCount++;
-			} else if (text[urlEndPos] === ')') {
-				parenCount--;
-			}
-			if (parenCount > 0) {
-				urlEndPos++;
-			}
-		}
-
-		if (parenCount === 0) {
-			const fullMatch = text.substring(startPos, urlEndPos + 1);
-			result = result.replace(fullMatch, linkText);
-		}
-	}
-
-	return result;
-}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"esbuild": "0.17.3",
 		"jest": "^30.0.3",
 		"obsidian": "latest",
+		"ts-jest": "^29.4.0",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
 	}

--- a/removeHyperlinks.test.ts
+++ b/removeHyperlinks.test.ts
@@ -1,4 +1,6 @@
-function removeHyperlinks(text) {
+import { describe, expect, test } from '@jest/globals';
+
+function removeHyperlinks(text:string): string {
 	let result = text;
 	let match;
 	const regex = /\[((?:[^\]\\]|\\.|\](?!\())*?)\]\(/g;

--- a/removeHyperlinks.test.ts
+++ b/removeHyperlinks.test.ts
@@ -1,38 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 
-function removeHyperlinks(text:string): string {
-	let result = text;
-	let match;
-	const regex = /\[((?:[^\]\\]|\\.|\](?!\())*?)\]\(/g;
-
-	while ((match = regex.exec(text)) !== null) {
-		const linkText = match[1];
-		const startPos = match.index;
-		const urlStartPos = match.index + match[0].length;
-
-		// Find the matching closing parenthesis
-		let parenCount = 1;
-		let urlEndPos = urlStartPos;
-
-		while (urlEndPos < text.length && parenCount > 0) {
-			if (text[urlEndPos] === '(') {
-				parenCount++;
-			} else if (text[urlEndPos] === ')') {
-				parenCount--;
-			}
-			if (parenCount > 0) {
-				urlEndPos++;
-			}
-		}
-
-		if (parenCount === 0) {
-			const fullMatch = text.substring(startPos, urlEndPos + 1);
-			result = result.replace(fullMatch, linkText);
-		}
-	}
-
-	return result;
-}
+import { removeHyperlinks } from './removeHyperlinks';
 
 describe('Remove Hyper Links Tests', () => {
   test('remove hyperlinks from text', () => {

--- a/removeHyperlinks.ts
+++ b/removeHyperlinks.ts
@@ -1,0 +1,33 @@
+export function removeHyperlinks(text:string): string {
+	let result = text;
+	let match;
+	const regex = /\[((?:[^\]\\]|\\.|\](?!\())*?)\]\(/g;
+
+	while ((match = regex.exec(text)) !== null) {
+		const linkText = match[1];
+		const startPos = match.index;
+		const urlStartPos = match.index + match[0].length;
+
+		// Find the matching closing parenthesis
+		let parenCount = 1;
+		let urlEndPos = urlStartPos;
+
+		while (urlEndPos < text.length && parenCount > 0) {
+			if (text[urlEndPos] === '(') {
+				parenCount++;
+			} else if (text[urlEndPos] === ')') {
+				parenCount--;
+			}
+			if (parenCount > 0) {
+				urlEndPos++;
+			}
+		}
+
+		if (parenCount === 0) {
+			const fullMatch = text.substring(startPos, urlEndPos + 1);
+			result = result.replace(fullMatch, linkText);
+		}
+	}
+
+	return result;
+}


### PR DESCRIPTION
The tests are great - many thanks for fixing the issues I reported.

## What this improves

I noticed that the tests used their own duplicate copy of `removeHyperlinks()`.

This is a bit error-prone, as it requires that anyone modifying the _real_ `removeHyperlinks()` in future remembers to copy every change to the tests, before running the tests and then committing.

I was going to add an issue suggesting that the tests be modified to import the "real" `removeHyperlinks()` - and then thought I would have a go at doing it myself.

## Changes made

The end result of the PR is:

1. Add dev dependency on `ts-jest`, and configure it
2. Rename the Jest test file from `.js` to `.ts` and make the tests still pass
3. Extract `removeHyperlinks()` to its own file
4. Change the Jest test to import that `removeHyperlinks()`

## Reviewing the change

Just in case you haven't seen this GitHub feature, you can:

1.  go to the 'Commits' tab of this PR
2. click on the first commit to review it
3. click on the `Next >` button at top-right to quickly advance through each commit, reviewing the safety of each change.

## After merging

I'm sure you know this, but it used to trip me up...

Remember to run `npm install` after you merge and pull the changes, so your own build keeps running.

